### PR TITLE
Make body text acquisition encoding-agnostic

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/EmailFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/EmailFixture.java
@@ -1,7 +1,6 @@
 package nl.hsac.fitnesse.fixture.slim;
 
 import nl.hsac.fitnesse.fixture.util.ThrowingFunction;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.mail.Address;
@@ -195,7 +194,7 @@ public class EmailFixture extends SlimFixture {
                 Object msgContent = msg.getContent();
                 if (msgContent instanceof MimeMultipart) {
                     Multipart multipart = (Multipart) msgContent;
-                    message = IOUtils.toString(multipart.getBodyPart(0).getInputStream());
+                    message = (String) multipart.getBodyPart(0).getContent();
                 } else {
                     message = msgContent.toString();
                 }


### PR DESCRIPTION
The current method of getting the body text from a MimeMultipart implicitly decodes the body using the platform default encoding (see https://commons.apache.org/proper/commons-io/javadocs/api-2.4/org/apache/commons/io/IOUtils.html#toString(java.io.InputStream) and the intro text at the top of that page), regardless of the encoding of the email. Special characters become gibberish when the email encoding and the platform default encoding do not match.

This happened during one of our tests in FitNesse, where the platform default encoding was windows-1252 and the email encoding was utf-8. Upon further experimentation, it also happened when the platform default encoding was utf-8 and the email encoding was windows-1252.

The official FAQ for JavaMail does not suggest using `IOUtils.toString()` to convert a message body to String. Instead, it suggests calling `getContent()` on the part and casting the result to String (see https://javaee.github.io/javamail/FAQ#mainbody). I tested the code in this pull request on all 4 possible encoding configurations involving windows-1252 and/or utf-8, and it correctly kept the special characters in every case.